### PR TITLE
Fix run on QHM edit page

### DIFF
--- a/assets/js/parts.js
+++ b/assets/js/parts.js
@@ -33,7 +33,8 @@
   $(window).on("hashchange", onHashChange);
 
   function onHashChange() {
-    partsName = location.hash.substr(1);
+    // remove GET query
+    partsName = location.hash.substr(1).split("?")[0];
     loadParts(partsName, function(){
       loadParts();
     });


### PR DESCRIPTION
## 概要

QHMの編集画面からの呼び出し時にテーマごとに切り替えられなくなっていた不具合を修正。
thickbox からの呼び出し時に付与される query により hash が意図しない形になっている場合に対処した。

例： `#haik_gok?KeepThis=true&`
